### PR TITLE
Use upstream's API header

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,5 +1,6 @@
 CXX_STD = CXX11
 PKG_LIBS=-L. -lswe
+PKG_CPPFLAGS=-I./libswe/
 
 all: $(SHLIB)
 $(SHLIB): libswe.a

--- a/src/swephapi.h
+++ b/src/swephapi.h
@@ -18,65 +18,12 @@ typedef int     AS_BOOL;
 typedef unsigned short UINT2;	/* unsigned 16 bits */
 # define ABS4	abs		/* abs function for long */
 
+typedef int32    centisec;       /* centiseconds used for angles and times */
+#define CS	(centisec)	/* use for casting */
+#define CSEC	centisec	/* use for typing */
 
-/* monday = 0, ... sunday = 6 */
-int swe_day_of_week(double jd);
-
-/* acquire the tidal acceleration */
-double swe_get_tid_acc() ;
-
-char * swe_version(char *);
-char * swe_get_library_path(char *);
-
-/* vr added functions */
-void swe_set_tid_acc(double t_acc);
-double swe_deltat(double tjd);
-void swe_set_ephe_path(char *);
-void swe_set_topo(double geolon, double geolat, double altitude);
-void swe_set_delta_t_userdef (double t_acc);
-
-
-/* planets, moon, nodes etc. */
-int32 swe_calc(
-        double tjd, int ipl, int32 iflag,
-        double *xx,
-        char *serr);
-
-/* star info. */
-int32 swe_fixstar(
-    char *star, double tjd, int32 iflag,
-    double *xx,
-    char *serr);
-
-void swe_azalt(
-    double tjd_ut,     /* UT */
-    int32 calc_flag,    /* SE_ECL2HOR=0 or SE_EQU2HOR=1 */
-    double *geopos, /* array of 3 doubles: geograph. long., lat., height */
-    double atpress,   /* atmospheric pressure in mbar (hPa) */
-    double attemp,   /* atmospheric temperature in degrees Celsius */  
-  double *xin,
-  double *xaz);
-
-int swe_rise_trans_true_hor(
-    double tjd_ut,               /* search after this time (UT) */
-int ipl,                        /* planet number, if planet or moon */
-char *starname,            /* star name, if star; must be NULL or empty, if ipl is used */
-int epheflag,              /* ephemeris flag */
-int rsmi,                     /* specifying: rise, set, orone of the two meridian transits*/
-double *geopos,            /* array of 3 doubles: geograph. long., lat., height */
-double atpress,             /* atmospheric pressure in mbar/hPa */
-double attemp,              /* atmospheric temperature in deg. C */
-double horhgt,              /* height of local horizon in deg at the point where the body rises or sets*/
-double *tret,                 /* return address (double) for rise time etc. */
-char *serr);                   /* return address for error message */
-
-
-
-int32 swe_calc_ut(double tjd_ut, int32 ipl, int32 iflag,
-	double *xx, char *serr);
-
-/* close Swiss Ephemeris */
-void swe_close(void);
+#define _SWEODEF_INCLUDED
+#include <swephexp.h>
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Instead of copying manually all the function definitions, it is
now possible to use upstream's header file directly. We only need
some DEFINEs from sweodef.h and have to make sure that the rest of
sweodef.h is not included.